### PR TITLE
Add image delete API and overlay update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
         <button type="submit">Upload</button>
       </form>
       <input type="text" id="search" placeholder="Search tags" />
+      <button id="deleteSelected" type="button">Delete Selected</button>
     </div>
   </header>
   <div id="main-container">

--- a/public/style.css
+++ b/public/style.css
@@ -170,3 +170,21 @@ img {
   color: var(--accent-teal);
   width: 100%;
 }
+
+.delete-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  z-index: 1;
+}
+
+.select-box {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary
- add single and bulk delete endpoints on the server
- show selection checkboxes and delete buttons in the gallery
- overlay now shows only the first tag
- add delete-selected control to the UI

## Testing
- `npm install`
- `npm start` *(fails if dependencies missing)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68681b7a0ac08333b1af3967b964bd19