### PR TITLE
Add prestart update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ npm start
 ```
 The server will start on [http://localhost:3000](http://localhost:3000).
 
+### Automatic Updates
+To start the server with an update check, run:
+
+```bash
+./prestart.sh
+```
+The script fetches any changes from the Git repository and prompts you to update.
+If `package.json` or `package-lock.json` changed, `npm install` will be executed
+before launching the server.
+
 If you are upgrading from a previous version of VisionVault, the server will
 automatically update your existing `visionvault.db` file to include a
 `created_at` column used for sorting images by upload time.

--- a/prestart.sh
+++ b/prestart.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Pre-startup script for VisionVault
+# Checks for git updates and optionally updates dependencies before starting.
+
+# fetch latest changes from remote
+if git fetch >/dev/null 2>&1 && ! git diff --quiet HEAD..origin/$(git rev-parse --abbrev-ref HEAD); then
+    echo "Updates are available for VisionVault."
+    read -p "Update now? [y/N] " -r reply
+    echo
+    if [[ $reply =~ ^[Yy]$ ]]; then
+        previous=$(git rev-parse HEAD)
+        echo "Pulling latest changes..."
+        git pull --ff-only
+        # Check if package files changed
+        if git diff --name-only $previous HEAD | grep -E '^(package|package-lock)\.json$' >/dev/null; then
+            echo "Dependency files changed. Running npm install..."
+            npm install
+        fi
+    fi
+fi
+
+# Start the application
+npm start
+


### PR DESCRIPTION
## Summary
- add `prestart.sh` script that checks for git updates on launch
- if the user opts in to update, install npm dependencies when package files change
- document `prestart.sh` usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68682133d8808333a3ec5220c516d069