### PR TITLE
Increase gallery image batch to 50

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -13,7 +13,7 @@ const dropZone = document.getElementById('dropZone');
 const imageInput = document.getElementById('imageInput');
 
 let offset = 0;
-const limit = 20;
+const limit = 50;
 let loading = false;
 let filters = {
   tag: '',
@@ -70,8 +70,6 @@ function createItem(img) {
   const meta = document.createElement('div');
   meta.className = 'meta-preview';
   meta.innerHTML = `
-    <div>Model: ${img.model || ''}</div>
-    <div>Seed: ${img.seed || ''}</div>
     <div class="tag-auto">${img.tags[0] || ''}</div>
   `;
 

--- a/src/server.js
+++ b/src/server.js
@@ -125,7 +125,7 @@ app.post('/api/upload', upload.array('images'), (req, res) => {
 });
 
 app.get('/api/images', (req, res) => {
-  const { tag, model, offset = 0, limit = 20, lora } = req.query;
+  const { tag, model, offset = 0, limit = 50, lora } = req.query;
   const conditions = [];
   const params = [];
   if (tag) {


### PR DESCRIPTION
## Summary
- load 50 images per request instead of 20
- show only tags in the preview overlay

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6868225f1b6c83338dc90d7975656dcf