### PR TITLE
Add tag cloud page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
       </form>
       <input type="text" id="search" placeholder="Search tags" />
       <button id="deleteSelected" type="button">Delete Selected</button>
+      <a href="tags.html" class="nav-link">Tag Cloud</a>
     </div>
   </header>
   <div id="main-container">

--- a/public/main.js
+++ b/public/main.js
@@ -22,6 +22,14 @@ let filters = {
   resolution: ''
 };
 
+// Apply tag from query parameter if present
+const urlParams = new URLSearchParams(window.location.search);
+const tagParam = urlParams.get('tag');
+if (tagParam) {
+  filters.tag = tagParam;
+  if (searchInput) searchInput.value = tagParam;
+}
+
 function buildQuery() {
   const params = new URLSearchParams();
   if (filters.tag) params.set('tag', filters.tag);

--- a/public/style.css
+++ b/public/style.css
@@ -200,3 +200,27 @@ img {
 .drop-zone.dragover {
   background: rgba(0, 0, 0, 0.3);
 }
+
+.nav-link {
+  color: var(--accent-teal);
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--accent-teal);
+  border-radius: 4px;
+}
+
+.tag-cloud {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  height: 600px;
+  margin: 2rem auto;
+}
+
+.tag-item {
+  position: absolute;
+  color: var(--accent-violet);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}

--- a/public/tags.html
+++ b/public/tags.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VisionVault - Tag Cloud</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>VisionVault</h1>
+    <div class="controls">
+      <a href="index.html" class="nav-link">Gallery</a>
+    </div>
+  </header>
+  <main id="tagCloud" class="tag-cloud"></main>
+  <script src="tags.js"></script>
+</body>
+</html>

--- a/public/tags.js
+++ b/public/tags.js
@@ -1,0 +1,35 @@
+const container = document.getElementById('tagCloud');
+
+async function fetchTags() {
+  const res = await fetch('/api/tags');
+  return res.json();
+}
+
+function render(tags) {
+  const max = tags[0] ? tags[0].count : 1;
+  const maxRadius = container.offsetWidth / 2 - 40;
+  const center = container.offsetWidth / 2;
+
+  tags.forEach((t) => {
+    const span = document.createElement('span');
+    span.className = 'tag-item';
+    span.textContent = t.tag;
+    const scale = t.count / max;
+    span.style.fontSize = 0.8 + scale * 2 + 'rem';
+    const radius = maxRadius * (1 - scale);
+    const angle = Math.random() * Math.PI * 2;
+    const x = center + radius * Math.cos(angle);
+    const y = center + radius * Math.sin(angle);
+    span.style.left = x + 'px';
+    span.style.top = y + 'px';
+    span.addEventListener('click', () => {
+      window.location.href = `index.html?tag=${encodeURIComponent(t.tag)}`;
+    });
+    container.appendChild(span);
+  });
+}
+
+window.addEventListener('load', async () => {
+  const tags = await fetchTags();
+  render(tags);
+});

--- a/src/server.js
+++ b/src/server.js
@@ -165,6 +165,22 @@ app.get('/api/images', (req, res) => {
   res.json(images);
 });
 
+// Aggregate tag counts for tag cloud
+app.get('/api/tags', (_req, res) => {
+  const rows = db.prepare('SELECT tags FROM images').all();
+  const counts = {};
+  rows.forEach((r) => {
+    const tagList = (r.tags || '').split(',').map((t) => t.trim().toLowerCase());
+    tagList.forEach((t) => {
+      if (t) counts[t] = (counts[t] || 0) + 1;
+    });
+  });
+  const tags = Object.entries(counts)
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count);
+  res.json(tags);
+});
+
 // Remove a single image by id
 app.delete('/api/images/:id', (req, res) => {
   const id = parseInt(req.params.id, 10);


### PR DESCRIPTION
## Summary
- add `/api/tags` endpoint
- create Tag Cloud page and script
- allow filtering by tag via URL
- link Tag Cloud from gallery
- add basic styles for cloud layout

## Testing
- `npm install`
- `npm start` *(server runs)*

------
https://chatgpt.com/codex/tasks/task_e_686824b569a8833384c4aab9e176f61f