### PR TITLE
Fix tag parsing to keep multi-word tags

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -73,8 +73,8 @@ function parsePrompt(params) {
 
 function toTags(prompt) {
   return prompt
-    .split(/[ ,]+/)
-    .map((t) => t.toLowerCase())
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
     .filter((t) => t);
 }
 


### PR DESCRIPTION
## Summary
- update `toTags` utility to parse comma-separated tags and keep spaces

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686826274db083338d80f1baf699ea82