### PR TITLE
Fix tag cloud parsing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -170,7 +170,7 @@ app.get('/api/tags', (_req, res) => {
   const rows = db.prepare('SELECT tags FROM images').all();
   const counts = {};
   rows.forEach((r) => {
-    const tagList = (r.tags || '').split(',').map((t) => t.trim().toLowerCase());
+    const tagList = toTags(r.tags || '');
     tagList.forEach((t) => {
       if (t) counts[t] = (counts[t] || 0) + 1;
     });


### PR DESCRIPTION
## Summary
- parse tags for the tag cloud using the same `toTags` helper

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6868297204208333bc3895db0197fceb