### PR TITLE
Fix tag parsing for quoted prompts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -68,13 +68,19 @@ function extractParameters(imagePath) {
 
 function parsePrompt(params) {
   const m = /Prompt:(.*?)(?:Negative prompt:|$)/i.exec(params);
-  return m ? m[1].trim() : '';
+  if (!m) return '';
+  return m[1].trim().replace(/^"|"$/g, '');
 }
 
 function toTags(prompt) {
   return prompt
     .split(',')
-    .map((t) => t.trim().toLowerCase())
+    .map((t) =>
+      t
+        .trim()
+        .replace(/^"|"$/g, '')
+        .toLowerCase()
+    )
     .filter((t) => t);
 }
 


### PR DESCRIPTION
## Summary
- strip surrounding quotes when parsing prompts
- sanitize tags so double quotes aren't stored as part of tags

## Testing
- `node --check src/server.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68682de424e483339f690c1e35c3e6d6