### PR TITLE
Improve tag cloud layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -210,17 +210,27 @@ img {
 }
 
 .tag-cloud {
-  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
   width: 100%;
-  max-width: 600px;
-  height: 600px;
+  max-width: 800px;
   margin: 2rem auto;
 }
 
 .tag-item {
-  position: absolute;
-  color: var(--accent-violet);
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  background: var(--accent-cobalt);
+  color: var(--text-color);
+  border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
   user-select: none;
+  transition: transform 0.2s;
+}
+
+.tag-item:hover {
+  transform: scale(1.1);
 }

--- a/public/tags.js
+++ b/public/tags.js
@@ -7,21 +7,13 @@ async function fetchTags() {
 
 function render(tags) {
   const max = tags[0] ? tags[0].count : 1;
-  const maxRadius = container.offsetWidth / 2 - 40;
-  const center = container.offsetWidth / 2;
 
   tags.forEach((t) => {
     const span = document.createElement('span');
     span.className = 'tag-item';
     span.textContent = t.tag;
     const scale = t.count / max;
-    span.style.fontSize = 0.8 + scale * 2 + 'rem';
-    const radius = maxRadius * (1 - scale);
-    const angle = Math.random() * Math.PI * 2;
-    const x = center + radius * Math.cos(angle);
-    const y = center + radius * Math.sin(angle);
-    span.style.left = x + 'px';
-    span.style.top = y + 'px';
+    span.style.fontSize = 0.8 + scale * 1.2 + 'rem';
     span.addEventListener('click', () => {
       window.location.href = `index.html?tag=${encodeURIComponent(t.tag)}`;
     });


### PR DESCRIPTION
## Summary
- modernize tag cloud layout so tags do not overlap
- update tag logic for new layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68682ef470108333b76af63d1acf2df5