### PR TITLE
Fix uploads and include PhotoSwipe dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "better-sqlite3": "^12.2.0",
         "express": "^4.18.2",
         "multer": "^2.0.1",
+        "photoswipe": "^5.4.4",
         "png-metadata": "^1.0.2"
       }
     },
@@ -872,6 +873,15 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/photoswipe": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
+      "integrity": "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.12.0"
+      }
     },
     "node_modules/png-metadata": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "better-sqlite3": "^12.2.0",
     "express": "^4.18.2",
     "multer": "^2.0.1",
+    "photoswipe": "^5.4.4",
     "png-metadata": "^1.0.2"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,16 @@ if (!cols.some((c) => c.name === 'created_at')) {
 
 // File upload configuration
 const uploadDir = path.join(__dirname, '..', 'public', 'images');
-const upload = multer({ dest: uploadDir });
+fs.mkdirSync(uploadDir, { recursive: true });
+const storage = multer.diskStorage({
+  destination: uploadDir,
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const name = `${Date.now()}-${Math.round(Math.random() * 1e6)}${ext}`;
+    cb(null, name);
+  }
+});
+const upload = multer({ storage });
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'public')));


### PR DESCRIPTION
## Summary
- add `photoswipe` to package.json
- persist original file extensions by customizing multer storage
- ensure image upload folder exists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868387419888333a14f1090febc2aa1