### PR TITLE
Fix missing extension for uploaded images

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -38,7 +38,11 @@ fs.mkdirSync(uploadDir, { recursive: true });
 const storage = multer.diskStorage({
   destination: uploadDir,
   filename: (_req, file, cb) => {
-    const ext = path.extname(file.originalname);
+    let ext = path.extname(file.originalname);
+    if (!ext) {
+      const map = { 'image/jpeg': '.jpg', 'image/png': '.png' };
+      ext = map[file.mimetype] || '';
+    }
     const name = `${Date.now()}-${Math.round(Math.random() * 1e6)}${ext}`;
     cb(null, name);
   }


### PR DESCRIPTION
## Summary
- ensure an extension is attached when saving uploaded images

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683983823c8333a354b9ed64226e94