### PR TITLE
Fix PhotoSwipe not opening

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -123,6 +123,10 @@ function createItem(img) {
   const el = document.createElement('img');
   el.src = img.url;
   el.alt = img.prompt || '';
+  el.addEventListener('load', () => {
+    if (!link.dataset.pswpWidth) link.dataset.pswpWidth = el.naturalWidth;
+    if (!link.dataset.pswpHeight) link.dataset.pswpHeight = el.naturalHeight;
+  });
   link.appendChild(el);
 
   const meta = document.createElement('div');


### PR DESCRIPTION
## Summary
- make sure PhotoSwipe slides know the image dimensions

## Testing
- `npm install`
- `npm start` *(fails: Cannot open in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68684485e7408333804a780e4fa94149