### PR TITLE
Remove PhotoSwipe viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "better-sqlite3": "^12.2.0",
         "express": "^4.18.2",
         "multer": "^2.0.1",
-        "photoswipe": "^5.4.4",
         "png-metadata": "^1.0.2"
       }
     },
@@ -873,15 +872,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
-    },
-    "node_modules/photoswipe": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.4.tgz",
-      "integrity": "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.12.0"
-      }
     },
     "node_modules/png-metadata": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "better-sqlite3": "^12.2.0",
     "express": "^4.18.2",
     "multer": "^2.0.1",
-    "photoswipe": "^5.4.4",
     "png-metadata": "^1.0.2"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -9,10 +9,6 @@
     rel="stylesheet"
   />
   <link rel="stylesheet" href="style.css" />
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/photoswipe@5/dist/photoswipe.css"
-  />
 </head>
 <body>
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
@@ -65,7 +61,15 @@
   <footer>
     <!-- Placeholder for footer content -->
   </footer>
-  <div id="pswp" class="pswp" tabindex="-1" role="dialog" aria-hidden="true"></div>
+  <div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content bg-dark text-light">
+        <div class="modal-body p-0 text-center">
+          <img id="modalImage" src="" class="img-fluid" alt="" />
+        </div>
+      </div>
+    </div>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- strip PhotoSwipe dependency from package files
- remove PhotoSwipe markup from `index.html` and add a Bootstrap modal for image viewing
- simplify gallery JavaScript to open images in the modal

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686846041d60833391d0fa7294eec74a