### PR TITLE
Add separate upload page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ automatically update your existing `visionvault.db` file to include a
 - **src/server.js** – Express server with image upload and search API.
 - **public/** – Static frontend implementing a simple gallery.
 
-Upload images using the drag-and-drop area on the main page. The metadata found in PNG files under the `Parameters` field is parsed automatically.
+Upload images through `upload.html`, which offers a drag-and-drop zone for quick imports. The metadata found in PNG files under the `Parameters` field is parsed automatically.

--- a/public/index.html
+++ b/public/index.html
@@ -12,22 +12,12 @@
 </head>
 <body>
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
-    <a class="navbar-brand logo-gradient" href="#">VisionVault</a>
+    <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
     <div class="d-flex align-items-center flex-wrap ms-auto gap-2 controls">
-      <form id="uploadForm" class="d-flex align-items-center">
-        <div id="dropZone" class="drop-zone me-2">Drag and drop images here or click</div>
-        <input
-          type="file"
-          name="images"
-          id="imageInput"
-          accept="image/png,image/jpeg"
-          multiple
-          style="display:none"
-        />
-      </form>
       <input type="text" id="search" class="form-control" placeholder="Search tags" />
       <button id="deleteSelected" type="button" class="btn btn-danger">Delete Selected</button>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
+      <a href="upload.html" class="btn btn-secondary">Upload</a>
     </div>
   </nav>
   <div id="main-container" class="container-fluid mt-3">

--- a/public/main.js
+++ b/public/main.js
@@ -244,19 +244,21 @@ manualTagToggle.addEventListener('change', () => {
 
 deleteSelectedBtn.addEventListener('click', deleteSelected);
 
-uploadForm.addEventListener('submit', (e) => e.preventDefault());
-dropZone.addEventListener('click', () => imageInput.click());
-dropZone.addEventListener('dragover', (e) => {
-  e.preventDefault();
-  dropZone.classList.add('dragover');
-});
-dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
-dropZone.addEventListener('drop', (e) => {
-  e.preventDefault();
-  dropZone.classList.remove('dragover');
-  uploadFiles(e.dataTransfer.files);
-});
-imageInput.addEventListener('change', () => uploadFiles(imageInput.files));
+if (uploadForm && dropZone && imageInput) {
+  uploadForm.addEventListener('submit', (e) => e.preventDefault());
+  dropZone.addEventListener('click', () => imageInput.click());
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('dragover');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('dragover');
+    uploadFiles(e.dataTransfer.files);
+  });
+  imageInput.addEventListener('change', () => uploadFiles(imageInput.files));
+}
 
 // initial load
 loadMore(true);

--- a/public/style.css
+++ b/public/style.css
@@ -237,3 +237,15 @@ img {
 .tag-item:hover {
   transform: scale(1.1);
 }
+
+/* Upload page layout */
+.upload-page .upload-container {
+  max-width: 600px;
+  margin: 4rem auto;
+}
+
+.upload-page .upload-drop-zone {
+  padding: 3rem;
+  font-size: 1.25rem;
+  margin: 1rem 0;
+}

--- a/public/tags.html
+++ b/public/tags.html
@@ -13,8 +13,9 @@
 <body>
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
     <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
-    <div class="ms-auto">
+    <div class="ms-auto d-flex gap-2">
       <a href="index.html" class="btn btn-secondary">Gallery</a>
+      <a href="upload.html" class="btn btn-secondary">Upload</a>
     </div>
   </nav>
   <main id="tagCloud" class="tag-cloud"></main>

--- a/public/upload.html
+++ b/public/upload.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VisionVault - Upload</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="upload-page">
+  <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
+    <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
+    <div class="ms-auto d-flex gap-2">
+      <a href="index.html" class="btn btn-secondary">Gallery</a>
+      <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
+    </div>
+  </nav>
+  <main class="upload-container container text-center">
+    <h1 class="my-4">Upload Images</h1>
+    <form id="uploadForm">
+      <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop images here or click</div>
+      <input type="file" id="imageInput" name="images" accept="image/png,image/jpeg" multiple style="display:none" />
+    </form>
+    <div id="uploadStatus" class="mt-3"></div>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="upload.js"></script>
+</body>
+</html>

--- a/public/upload.js
+++ b/public/upload.js
@@ -1,0 +1,35 @@
+const uploadForm = document.getElementById('uploadForm');
+const dropZone = document.getElementById('dropZone');
+const imageInput = document.getElementById('imageInput');
+const statusEl = document.getElementById('uploadStatus');
+
+function uploadFiles(files) {
+  if (!files || !files.length) return;
+  const formData = new FormData();
+  Array.from(files).forEach(f => formData.append('images', f));
+  fetch('/api/upload', {
+    method: 'POST',
+    body: formData,
+  })
+    .then(() => {
+      statusEl.textContent = 'Upload complete!';
+      imageInput.value = '';
+    })
+    .catch(() => {
+      statusEl.textContent = 'Upload failed.';
+    });
+}
+
+uploadForm.addEventListener('submit', e => e.preventDefault());
+dropZone.addEventListener('click', () => imageInput.click());
+dropZone.addEventListener('dragover', e => {
+  e.preventDefault();
+  dropZone.classList.add('dragover');
+});
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', e => {
+  e.preventDefault();
+  dropZone.classList.remove('dragover');
+  uploadFiles(e.dataTransfer.files);
+});
+imageInput.addEventListener('change', () => uploadFiles(imageInput.files));


### PR DESCRIPTION
## Summary
- move upload form from gallery header into its own page
- link the new uploader page from the gallery and tag cloud
- polish style for upload page and make main script resilient
- update README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68684984d40c83339fb7986aa2d20409