### PR TITLE
Fix sqlite path when using docker

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,9 @@ const PORT = process.env.PORT || 3000;
 
 // Database setup. Allow overriding the location for Docker or custom setups.
 const dbPath = process.env.DB_PATH || path.join(__dirname, '..', 'visionvault.db');
+// Ensure the directory for the database exists (useful for Docker volumes)
+const dbDir = path.dirname(dbPath);
+fs.mkdirSync(dbDir, { recursive: true });
 const db = new Database(dbPath);
 db.prepare(`CREATE TABLE IF NOT EXISTS images (
   id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- ensure the directory for the DB_PATH exists before opening the SQLite database

## Testing
- `npm test` *(fails: Missing script)*
- `node src/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6868d8820afc8333931431a0af62f9d5