### PR TITLE
Add Node dependencies to VisionSuit anchor

### DIFF
--- a/visionsuit-anchor.yaml
+++ b/visionsuit-anchor.yaml
@@ -1,0 +1,12 @@
+# VisionSuit anchor configuration for VisionVault
+# Specifies extra packages and runtime environment variables
+apt_packages:
+  - git
+  - nodejs
+  - npm
+pip_packages: []
+
+env:
+  NODE_ENV: "production"
+  DB_PATH: "/app/data/visionvault.db"
+  PORT: "3000"


### PR DESCRIPTION
## Summary
- include `nodejs` and `npm` apt packages in `visionsuit-anchor.yaml`

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68690432f9f48333ba932c14a6c83bdf