### PR TITLE
Add gallery sorting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Drag-and-drop bulk uploads with automatic extraction of PNG `Parameters` metadata
 - Images and metadata stored in a local SQLite database
 - Infinite scrolling gallery with quick tag preview
+- Sorting by date or first tag (trigger)
 - Filters for tags, model names, LoRA references and resolution
 - Tag cloud page showing popular keywords
 - Metadata drawer and fullscreen modal per image

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,11 @@
     <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
     <div class="d-flex align-items-center flex-wrap ms-auto gap-2 controls">
       <input type="text" id="search" class="form-control" placeholder="Search tags" />
+      <select id="sortSelect" class="form-select">
+        <option value="date_desc">Newest first</option>
+        <option value="date_asc">Oldest first</option>
+        <option value="trigger_asc">Trigger A-Z</option>
+      </select>
       <button id="deleteSelected" type="button" class="btn btn-danger">Delete Selected</button>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
       <a href="upload.html" class="btn btn-secondary">Upload</a>

--- a/public/main.js
+++ b/public/main.js
@@ -13,6 +13,7 @@ const deleteSelectedBtn = document.getElementById('deleteSelected');
 const uploadForm = document.getElementById('uploadForm');
 const dropZone = document.getElementById('dropZone');
 const imageInput = document.getElementById('imageInput');
+const sortSelect = document.getElementById('sortSelect');
 
 // Simple helper so all debug output is grouped and easy to filter
 function debug(...args) {
@@ -26,7 +27,8 @@ let filters = {
   tag: '',
   model: '',
   lora: false,
-  resolution: ''
+  resolution: '',
+  sort: 'date_desc'
 };
 
 
@@ -36,6 +38,11 @@ const tagParam = urlParams.get('tag');
 if (tagParam) {
   filters.tag = tagParam;
   if (searchInput) searchInput.value = tagParam;
+}
+const sortParam = urlParams.get('sort');
+if (sortParam) {
+  filters.sort = sortParam;
+  if (sortSelect) sortSelect.value = sortParam;
 }
 
 function buildQuery() {
@@ -50,6 +57,7 @@ function buildQuery() {
       params.set('height', h.trim());
     }
   }
+  if (filters.sort) params.set('sort', filters.sort);
   params.set('offset', offset);
   params.set('limit', limit);
   return params.toString();
@@ -234,6 +242,13 @@ searchInput.addEventListener('input', () => {
   filters.tag = searchInput.value.trim();
   loadMore(true);
 });
+
+if (sortSelect) {
+  sortSelect.addEventListener('change', () => {
+    filters.sort = sortSelect.value;
+    loadMore(true);
+  });
+}
 
 manualTagToggle.addEventListener('change', () => {
   const showManual = manualTagToggle.checked;


### PR DESCRIPTION
## Summary
- allow sorting by creation date or trigger tag
- add dropdown on gallery page to choose sort order
- propagate sort selection to API via new query param
- document new sorting feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a2ba0dbe88333ab1d419071ae485e