### PR TITLE
Enhance uploader with progress queue

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -249,3 +249,11 @@ img {
   font-size: 1.25rem;
   margin: 1rem 0;
 }
+
+.upload-page #uploadQueue {
+  text-align: left;
+}
+
+.upload-page .progress {
+  height: 0.75rem;
+}

--- a/public/upload.html
+++ b/public/upload.html
@@ -21,6 +21,7 @@
       <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop images here or click</div>
       <input type="file" id="imageInput" name="images" accept="image/png,image/jpeg" multiple style="display:none" />
     </form>
+    <ul id="uploadQueue" class="list-group mt-3"></ul>
     <div id="uploadStatus" class="mt-3"></div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/public/upload.js
+++ b/public/upload.js
@@ -2,34 +2,73 @@ const uploadForm = document.getElementById('uploadForm');
 const dropZone = document.getElementById('dropZone');
 const imageInput = document.getElementById('imageInput');
 const statusEl = document.getElementById('uploadStatus');
+const queueEl = document.getElementById('uploadQueue');
 
-function uploadFiles(files) {
-  if (!files || !files.length) return;
-  const formData = new FormData();
-  Array.from(files).forEach(f => formData.append('images', f));
-  fetch('/api/upload', {
-    method: 'POST',
-    body: formData,
-  })
-    .then(() => {
-      statusEl.textContent = 'Upload complete!';
-      imageInput.value = '';
-    })
-    .catch(() => {
-      statusEl.textContent = 'Upload failed.';
-    });
+const queue = [];
+let uploading = false;
+
+function addFiles(files) {
+  Array.from(files).forEach(file => {
+    const item = document.createElement('li');
+    item.className = 'list-group-item d-flex justify-content-between align-items-center';
+    item.textContent = file.name;
+
+    const progress = document.createElement('div');
+    progress.className = 'progress flex-grow-1 ms-2';
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar';
+    bar.style.width = '0%';
+    progress.appendChild(bar);
+    item.appendChild(progress);
+    queueEl.appendChild(item);
+
+    queue.push({ file, bar, item });
+  });
+  if (!uploading) processQueue();
 }
 
-uploadForm.addEventListener('submit', e => e.preventDefault());
+function processQueue() {
+  if (!queue.length) {
+    uploading = false;
+    statusEl.textContent = 'All uploads complete';
+    return;
+  }
+  uploading = true;
+  const { file, bar, item } = queue.shift();
+  statusEl.textContent = `Uploading ${file.name}...`;
+  const formData = new FormData();
+  formData.append('images', file);
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/api/upload');
+  xhr.upload.onprogress = (e) => {
+    if (e.lengthComputable) {
+      const percent = (e.loaded / e.total) * 100;
+      bar.style.width = `${percent}%`;
+    }
+  };
+  xhr.onload = () => {
+    bar.style.width = '100%';
+    setTimeout(() => item.remove(), 500);
+    processQueue();
+  };
+  xhr.onerror = () => {
+    bar.classList.add('bg-danger');
+    processQueue();
+  };
+  xhr.send(formData);
+}
+
 dropZone.addEventListener('click', () => imageInput.click());
-dropZone.addEventListener('dragover', e => {
+dropZone.addEventListener('dragover', (e) => {
   e.preventDefault();
   dropZone.classList.add('dragover');
 });
 dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
-dropZone.addEventListener('drop', e => {
+dropZone.addEventListener('drop', (e) => {
   e.preventDefault();
   dropZone.classList.remove('dragover');
-  uploadFiles(e.dataTransfer.files);
+  addFiles(e.dataTransfer.files);
 });
-imageInput.addEventListener('change', () => uploadFiles(imageInput.files));
+imageInput.addEventListener('change', () => addFiles(imageInput.files));
+
+uploadForm.addEventListener('submit', (e) => e.preventDefault());


### PR DESCRIPTION
## Summary
- add upload queue list to the upload page
- implement per-file progress bars and sequential upload logic
- style upload queue and progress bars for a clean look

## Testing
- `node --check public/upload.js`


------
https://chatgpt.com/codex/tasks/task_e_686a2ef863bc83339ff567c4a9ffa1dc