### PR TITLE
Add light theme toggle to gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Tag cloud page showing popular keywords
 - Metadata drawer and fullscreen modal per image
 - Single or bulk deletion of images
+- Light/dark theme toggle for improved usability
 - Optional `prestart.sh` script to pull updates and reinstall dependencies
 
 ## Use Cases

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
       <button id="deleteSelected" type="button" class="btn btn-danger">Delete Selected</button>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
       <a href="upload.html" class="btn btn-secondary">Upload</a>
+      <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>
   </nav>
   <div id="main-container" class="container-fluid mt-3">

--- a/public/main.js
+++ b/public/main.js
@@ -14,6 +14,7 @@ const uploadForm = document.getElementById('uploadForm');
 const dropZone = document.getElementById('dropZone');
 const imageInput = document.getElementById('imageInput');
 const sortSelect = document.getElementById('sortSelect');
+const themeToggle = document.getElementById('themeToggle');
 
 // Simple helper so all debug output is grouped and easy to filter
 function debug(...args) {
@@ -256,6 +257,26 @@ manualTagToggle.addEventListener('change', () => {
     el.style.display = showManual ? 'none' : '';
   });
 });
+
+function applyTheme(theme) {
+  if (theme === 'light') {
+    document.body.classList.add('light-theme');
+    themeToggle.textContent = '🌙';
+  } else {
+    document.body.classList.remove('light-theme');
+    themeToggle.textContent = '☀';
+  }
+  localStorage.setItem('vv-theme', theme);
+}
+
+themeToggle.addEventListener('click', () => {
+  const current = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+  const next = current === 'light' ? 'dark' : 'light';
+  applyTheme(next);
+});
+
+// Apply stored theme on load
+applyTheme(localStorage.getItem('vv-theme') || 'dark');
 
 deleteSelectedBtn.addEventListener('click', deleteSelected);
 

--- a/public/style.css
+++ b/public/style.css
@@ -12,10 +12,20 @@ body {
   font-family: 'Inter', 'IBM Plex Sans', sans-serif;
   background-color: var(--bg-dark);
   color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.light-theme {
+  --bg-dark: var(--bg-light);
+  --text-color: #1f2937;
 }
 
 nav.navbar {
   border-bottom: 2px solid var(--accent-cobalt);
+}
+
+.light-theme nav.navbar {
+  background-color: var(--bg-light) !important;
 }
 
 .text-violet {
@@ -61,6 +71,8 @@ img {
   height: auto;
   display: block;
   border: 1px solid var(--accent-cobalt);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .info-overlay {
@@ -92,6 +104,10 @@ img {
   transition: transform 0.3s;
   position: relative;
   z-index: 2;
+}
+
+.light-theme #sidebar {
+  background: var(--bg-light);
 }
 
 #sidebar.collapsed {
@@ -133,6 +149,10 @@ img {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+}
+
+.light-theme .meta-preview {
+  background: rgba(255, 255, 255, 0.7);
 }
 
 /* Offcanvas tweaks */

--- a/public/tags.html
+++ b/public/tags.html
@@ -16,6 +16,7 @@
     <div class="ms-auto d-flex gap-2">
       <a href="index.html" class="btn btn-secondary">Gallery</a>
       <a href="upload.html" class="btn btn-secondary">Upload</a>
+      <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>
   </nav>
   <main id="tagCloud" class="tag-cloud"></main>

--- a/public/tags.js
+++ b/public/tags.js
@@ -1,4 +1,5 @@
 const container = document.getElementById('tagCloud');
+const themeToggle = document.getElementById('themeToggle');
 
 async function fetchTags() {
   const res = await fetch('/api/tags');
@@ -25,3 +26,22 @@ window.addEventListener('load', async () => {
   const tags = await fetchTags();
   render(tags);
 });
+
+function applyTheme(theme) {
+  if (theme === 'light') {
+    document.body.classList.add('light-theme');
+    themeToggle.textContent = '🌙';
+  } else {
+    document.body.classList.remove('light-theme');
+    themeToggle.textContent = '☀';
+  }
+  localStorage.setItem('vv-theme', theme);
+}
+
+themeToggle.addEventListener('click', () => {
+  const current = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+  const next = current === 'light' ? 'dark' : 'light';
+  applyTheme(next);
+});
+
+applyTheme(localStorage.getItem('vv-theme') || 'dark');

--- a/public/upload.html
+++ b/public/upload.html
@@ -13,6 +13,7 @@
     <div class="ms-auto d-flex gap-2">
       <a href="index.html" class="btn btn-secondary">Gallery</a>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
+      <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>
   </nav>
   <main class="upload-container container text-center">

--- a/public/upload.js
+++ b/public/upload.js
@@ -3,6 +3,7 @@ const dropZone = document.getElementById('dropZone');
 const imageInput = document.getElementById('imageInput');
 const statusEl = document.getElementById('uploadStatus');
 const queueEl = document.getElementById('uploadQueue');
+const themeToggle = document.getElementById('themeToggle');
 
 const queue = [];
 let uploading = false;
@@ -72,3 +73,22 @@ dropZone.addEventListener('drop', (e) => {
 imageInput.addEventListener('change', () => addFiles(imageInput.files));
 
 uploadForm.addEventListener('submit', (e) => e.preventDefault());
+
+function applyTheme(theme) {
+  if (theme === 'light') {
+    document.body.classList.add('light-theme');
+    themeToggle.textContent = '🌙';
+  } else {
+    document.body.classList.remove('light-theme');
+    themeToggle.textContent = '☀';
+  }
+  localStorage.setItem('vv-theme', theme);
+}
+
+themeToggle.addEventListener('click', () => {
+  const current = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+  const next = current === 'light' ? 'dark' : 'light';
+  applyTheme(next);
+});
+
+applyTheme(localStorage.getItem('vv-theme') || 'dark');


### PR DESCRIPTION
## Summary
- modernize styles with soft shadows and transitions
- add light mode support and theme toggle button on every page
- persist theme preference locally
- document theme toggle feature

## Testing
- `npm install`
- `node src/server.js` *(fails before install; succeeds after)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a303373688333b3a261a5c6d28210