### PR TITLE
Implement dashboard and new gallery layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Express server exposes the following endpoints:
 
 ### Project Structure
 - **src/server.js** – main server implementation
-- **public/** – static files for the gallery and upload pages
+- **public/** – static files for the dashboard, gallery and upload pages
 
-Upload images through `public/upload.html`. Hover an image in the gallery to preview its main tag or open the metadata drawer for complete details.
+The default `index.html` now shows a dashboard with basic statistics. Browse images through `public/gallery.html`. Upload images via `public/upload.html`. Hover an image in the gallery to preview its main tag or open the metadata drawer for complete details.
 

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>VisionVault - Gallery</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
+    <h1 class="text-lg font-semibold"><a href="index.html">VisionVault</a></h1>
+    <nav class="space-x-2 flex items-center">
+      <button id="toggleSidebar" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">☰</button>
+      <input type="text" id="search" class="px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Search tags" />
+      <button id="deleteSelected" type="button" class="px-3 py-1 bg-red-700 hover:bg-red-600 rounded">Delete</button>
+      <a href="tags.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+      <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
+      <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
+    </nav>
+  </header>
+  <div class="flex h-[calc(100vh-56px)]">
+    <aside id="sidebar" class="w-64 bg-gray-800 border-r border-gray-700 p-6 overflow-y-auto">
+      <h2 class="text-md font-semibold mb-4">Filter</h2>
+      <form id="filterForm" class="space-y-4 text-sm">
+        <input type="text" id="modelFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Model" />
+        <input type="text" id="keywordFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Keyword" />
+        <input type="text" id="resFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Resolution e.g. 512x512" />
+        <label class="inline-flex items-center"><input type="checkbox" id="loraFilter" class="mr-2" />LoRA</label>
+        <select id="sortSelect" class="w-full px-2 py-1 bg-gray-700 rounded">
+          <option value="date_desc">Newest first</option>
+          <option value="date_asc">Oldest first</option>
+          <option value="trigger_asc">Trigger A-Z</option>
+        </select>
+        <button type="submit" class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded">Apply</button>
+      </form>
+      <label class="tag-switch mt-3 block text-sm"><input type="checkbox" id="manualTagToggle" class="mr-2" /> Manual tags</label>
+    </aside>
+    <main id="gallery" class="flex-1 p-6 overflow-y-auto bg-gray-900">
+      <p class="placeholder text-center text-teal-400">Galerie wird hier erscheinen...</p>
+    </main>
+  </div>
+  <div id="drawer" class="offcanvas offcanvas-end bg-dark text-light" tabindex="-1">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title">Metadata</h5>
+      <button id="drawerClose" type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div id="drawerContent" class="offcanvas-body"></div>
+  </div>
+  <footer>
+    <!-- Placeholder for footer content -->
+  </footer>
+  <div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content bg-dark text-light">
+        <div class="modal-body p-0 text-center">
+          <img id="modalImage" src="" class="img-fluid" alt="" />
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -3,70 +3,83 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>VisionVault</title>
-  <link
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-    rel="stylesheet"
-  />
+  <title>VisionVault - Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
     <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
-    <div class="d-flex align-items-center flex-wrap ms-auto gap-2 controls">
-      <input type="text" id="search" class="form-control" placeholder="Search tags" />
-      <select id="sortSelect" class="form-select">
-        <option value="date_desc">Newest first</option>
-        <option value="date_asc">Oldest first</option>
-        <option value="trigger_asc">Trigger A-Z</option>
-      </select>
-      <button id="deleteSelected" type="button" class="btn btn-danger">Delete Selected</button>
+    <div class="ms-auto d-flex gap-2">
+      <a href="gallery.html" class="btn btn-secondary">Gallery</a>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
       <a href="upload.html" class="btn btn-secondary">Upload</a>
       <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>
   </nav>
-  <div id="main-container" class="container-fluid mt-3">
-    <div class="row">
-      <aside id="sidebar" class="col-md-3 col-lg-2 collapsed">
-        <button id="toggleSidebar" class="btn btn-outline-teal mb-2">☰</button>
-        <form id="filterForm" class="vstack gap-2">
-          <input type="text" id="modelFilter" class="form-control" placeholder="Model" />
-          <input type="text" id="keywordFilter" class="form-control" placeholder="Keyword" />
-          <input type="text" id="resFilter" class="form-control" placeholder="Resolution e.g. 512x512" />
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="loraFilter" />
-            <label class="form-check-label" for="loraFilter">LoRA</label>
+  <main class="container py-5">
+    <h1 class="mb-4">Dashboard</h1>
+    <div id="stats" class="row g-4">
+      <div class="col-md-4">
+        <div class="card text-center bg-dark">
+          <div class="card-body">
+            <h2 id="statImages" class="card-title display-5">0</h2>
+            <p class="card-text">Images</p>
           </div>
-          <button type="submit" class="btn btn-primary">Apply</button>
-        </form>
-        <label class="tag-switch mt-3"><input type="checkbox" id="manualTagToggle" /> Manual tags</label>
-      </aside>
-      <main id="gallery" class="masonry col">
-        <p class="placeholder">Galerie wird hier erscheinen...</p>
-      </main>
-    </div>
-  </div>
-  <div id="drawer" class="offcanvas offcanvas-end bg-dark text-light" tabindex="-1">
-    <div class="offcanvas-header">
-      <h5 class="offcanvas-title">Metadata</h5>
-      <button id="drawerClose" type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-    </div>
-    <div id="drawerContent" class="offcanvas-body"></div>
-  </div>
-  <footer>
-    <!-- Placeholder for footer content -->
-  </footer>
-  <div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-      <div class="modal-content bg-dark text-light">
-        <div class="modal-body p-0 text-center">
-          <img id="modalImage" src="" class="img-fluid" alt="" />
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card text-center bg-dark">
+          <div class="card-body">
+            <h2 id="statTags" class="card-title display-5">0</h2>
+            <p class="card-text">Unique Tags</p>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card text-center bg-dark">
+          <div class="card-body">
+            <h2 id="statModels" class="card-title display-5">0</h2>
+            <p class="card-text">Models Used</p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+    <h2 class="mt-5">Top Tags</h2>
+    <ul id="topTags" class="list-inline mt-3"></ul>
+  </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script type="module" src="main.js"></script>
+  <script>
+    const themeToggle = document.getElementById('themeToggle');
+    function applyTheme(theme) {
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+        themeToggle.textContent = '🌙';
+      } else {
+        document.body.classList.remove('light-theme');
+        themeToggle.textContent = '☀';
+      }
+      localStorage.setItem('vv-theme', theme);
+    }
+    themeToggle.addEventListener('click', () => {
+      const current = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+      applyTheme(current === 'light' ? 'dark' : 'light');
+    });
+    applyTheme(localStorage.getItem('vv-theme') || 'dark');
+
+    fetch('/api/stats').then(r => r.json()).then(data => {
+      document.getElementById('statImages').textContent = data.images;
+      document.getElementById('statTags').textContent = data.tags;
+      document.getElementById('statModels').textContent = data.models;
+      const ul = document.getElementById('topTags');
+      ul.innerHTML = '';
+      data.topTags.forEach(t => {
+        const li = document.createElement('li');
+        li.className = 'list-inline-item badge bg-secondary m-1';
+        li.textContent = `${t.tag} (${t.count})`;
+        ul.appendChild(li);
+      });
+    });
+  </script>
 </body>
 </html>

--- a/public/tags.html
+++ b/public/tags.html
@@ -14,7 +14,7 @@
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
     <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
     <div class="ms-auto d-flex gap-2">
-      <a href="index.html" class="btn btn-secondary">Gallery</a>
+      <a href="gallery.html" class="btn btn-secondary">Gallery</a>
       <a href="upload.html" class="btn btn-secondary">Upload</a>
       <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>

--- a/public/tags.js
+++ b/public/tags.js
@@ -16,7 +16,7 @@ function render(tags) {
     const scale = t.count / max;
     span.style.fontSize = 0.8 + scale * 1.2 + 'rem';
     span.addEventListener('click', () => {
-      window.location.href = `index.html?tag=${encodeURIComponent(t.tag)}`;
+      window.location.href = `gallery.html?tag=${encodeURIComponent(t.tag)}`;
     });
     container.appendChild(span);
   });

--- a/public/upload.html
+++ b/public/upload.html
@@ -11,7 +11,7 @@
   <nav class="navbar navbar-dark bg-dark border-bottom border-primary px-3">
     <a class="navbar-brand logo-gradient" href="index.html">VisionVault</a>
     <div class="ms-auto d-flex gap-2">
-      <a href="index.html" class="btn btn-secondary">Gallery</a>
+      <a href="gallery.html" class="btn btn-secondary">Gallery</a>
       <a href="tags.html" class="btn btn-secondary">Tag Cloud</a>
       <button id="themeToggle" type="button" class="btn btn-outline-teal" title="Toggle theme">☀</button>
     </div>


### PR DESCRIPTION
## Summary
- add `/api/stats` endpoint for dashboard data
- build a Tailwind-based gallery page
- convert `index.html` to a statistics dashboard
- update links in other pages
- redirect tag cloud clicks to new gallery
- document new layout

## Testing
- `npm install`
- `node --check src/server.js`
- `node src/server.js & sleep 2; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_686a34d4bc088333a3aec44f054b8cd2