### PR TITLE
Add storage metrics and interactive dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
   <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
@@ -33,7 +34,7 @@
       <div class="container">
         <h1 class="mb-4">Dashboard</h1>
         <div id="stats" class="row g-4">
-          <div class="col-md-4">
+          <div class="col-md-3">
             <div class="card text-center bg-dark">
               <div class="card-body">
                 <h2 id="statImages" class="card-title display-5">0</h2>
@@ -41,7 +42,7 @@
               </div>
             </div>
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
             <div class="card text-center bg-dark">
               <div class="card-body">
                 <h2 id="statTags" class="card-title display-5">0</h2>
@@ -49,7 +50,7 @@
               </div>
             </div>
           </div>
-          <div class="col-md-4">
+          <div class="col-md-3">
             <div class="card text-center bg-dark">
               <div class="card-body">
                 <h2 id="statModels" class="card-title display-5">0</h2>
@@ -57,7 +58,17 @@
               </div>
             </div>
           </div>
+          <div class="col-md-3">
+            <div class="card text-center bg-dark">
+              <div class="card-body">
+                <h2 id="statStorage" class="card-title h3">0</h2>
+                <p class="card-text">Storage Used</p>
+              </div>
+            </div>
+          </div>
         </div>
+        <canvas id="countChart" class="my-4"></canvas>
+        <canvas id="storageChart" class="my-4"></canvas>
         <h2 class="mt-5">Top Tags</h2>
         <ul id="topTags" class="list-inline mt-3"></ul>
       </div>
@@ -86,12 +97,43 @@
       document.getElementById('statImages').textContent = data.images;
       document.getElementById('statTags').textContent = data.tags;
       document.getElementById('statModels').textContent = data.models;
+      const mb = v => (v / (1024 * 1024)).toFixed(2);
+      document.getElementById('statStorage').textContent = `${mb(data.storage.used)} / ${mb(data.storage.total)} MB`;
+
+      new Chart(document.getElementById('countChart').getContext('2d'), {
+        type: 'bar',
+        data: {
+          labels: ['Images', 'Tags'],
+          datasets: [{
+            data: [data.images, data.tags],
+            backgroundColor: ['#8a2be2', '#008080']
+          }]
+        },
+        options: { plugins: { legend: { display: false } } }
+      });
+
+      new Chart(document.getElementById('storageChart').getContext('2d'), {
+        type: 'doughnut',
+        data: {
+          labels: ['Used', 'Free'],
+          datasets: [{
+            data: [data.storage.used, data.storage.total - data.storage.used],
+            backgroundColor: ['#0047ab', '#8a2be2']
+          }]
+        },
+        options: { plugins: { legend: { position: 'bottom' } } }
+      });
+
       const ul = document.getElementById('topTags');
       ul.innerHTML = '';
       data.topTags.forEach(t => {
         const li = document.createElement('li');
-        li.className = 'list-inline-item badge bg-secondary m-1';
-        li.textContent = `${t.tag} (${t.count})`;
+        li.className = 'list-inline-item m-1';
+        const a = document.createElement('a');
+        a.className = 'badge bg-secondary';
+        a.textContent = `${t.tag} (${t.count})`;
+        a.href = `gallery.html?tag=${encodeURIComponent(t.tag)}`;
+        li.appendChild(a);
         ul.appendChild(li);
       });
     });


### PR DESCRIPTION
## Summary
- expose upload directory disk usage in `/api/stats`
- chart dashboard statistics using Chart.js
- show storage usage and make top tags clickable

## Testing
- `npm install`
- `npm start` *(fails: missing due to interactive run halting)*

------
https://chatgpt.com/codex/tasks/task_e_686a382908a88333aa94d517c728fc53