### PR TITLE
Adjust dashboard layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,7 @@
               <div class="card-body">
                 <h2 id="statImages" class="card-title display-5">0</h2>
                 <p class="card-text">Images</p>
+                <p id="statImagesText" class="card-text small text-muted"></p>
               </div>
             </div>
           </div>
@@ -47,6 +48,7 @@
               <div class="card-body">
                 <h2 id="statTags" class="card-title display-5">0</h2>
                 <p class="card-text">Unique Tags</p>
+                <p id="statTagsText" class="card-text small text-muted"></p>
               </div>
             </div>
           </div>
@@ -55,6 +57,7 @@
               <div class="card-body">
                 <h2 id="statModels" class="card-title display-5">0</h2>
                 <p class="card-text">Models Used</p>
+                <p id="statModelsText" class="card-text small text-muted"></p>
               </div>
             </div>
           </div>
@@ -63,12 +66,15 @@
               <div class="card-body">
                 <h2 id="statStorage" class="card-title h3">0</h2>
                 <p class="card-text">Storage Used</p>
+                <p id="statStorageText" class="card-text small text-muted"></p>
               </div>
             </div>
           </div>
         </div>
-        <canvas id="countChart" class="my-4"></canvas>
-        <canvas id="storageChart" class="my-4"></canvas>
+        <div class="row g-4 my-4">
+          <div class="col-md-6"><canvas id="countChart" class="chart-canvas"></canvas></div>
+          <div class="col-md-6"><canvas id="storageChart" class="chart-canvas"></canvas></div>
+        </div>
         <h2 class="mt-5">Top Tags</h2>
         <ul id="topTags" class="list-inline mt-3"></ul>
       </div>
@@ -99,6 +105,10 @@
       document.getElementById('statModels').textContent = data.models;
       const mb = v => (v / (1024 * 1024)).toFixed(2);
       document.getElementById('statStorage').textContent = `${mb(data.storage.used)} / ${mb(data.storage.total)} MB`;
+      document.getElementById('statImagesText').textContent = `You have ${data.images} images`;
+      document.getElementById('statTagsText').textContent = data.topTags.length ? `Top tag: ${data.topTags[0].tag}` : '';
+      document.getElementById('statModelsText').textContent = `${data.models} models detected`;
+      document.getElementById('statStorageText').textContent = `Using ${mb(data.storage.used)} MB`;
 
       new Chart(document.getElementById('countChart').getContext('2d'), {
         type: 'bar',

--- a/public/style.css
+++ b/public/style.css
@@ -277,3 +277,9 @@ img {
 .upload-page .progress {
   height: 0.75rem;
 }
+
+.chart-canvas {
+  max-width: 100%;
+  height: 220px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- resize dashboard charts and place them side-by-side
- show additional statistics text in the summary cards
- add CSS for the smaller chart canvases

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a3967038c8333a5bf604eea708f37