### PR TITLE
Fix dashboard stats text color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,38 +35,38 @@
         <h1 class="mb-4">Dashboard</h1>
         <div id="stats" class="row g-4">
           <div class="col-md-3">
-            <div class="card text-center bg-dark">
+            <div class="card text-center bg-dark text-white">
               <div class="card-body">
                 <h2 id="statImages" class="card-title display-5">0</h2>
                 <p class="card-text">Images</p>
-                <p id="statImagesText" class="card-text small text-muted"></p>
+                <p id="statImagesText" class="card-text small text-light"></p>
               </div>
             </div>
           </div>
           <div class="col-md-3">
-            <div class="card text-center bg-dark">
+            <div class="card text-center bg-dark text-white">
               <div class="card-body">
                 <h2 id="statTags" class="card-title display-5">0</h2>
                 <p class="card-text">Unique Tags</p>
-                <p id="statTagsText" class="card-text small text-muted"></p>
+                <p id="statTagsText" class="card-text small text-light"></p>
               </div>
             </div>
           </div>
           <div class="col-md-3">
-            <div class="card text-center bg-dark">
+            <div class="card text-center bg-dark text-white">
               <div class="card-body">
                 <h2 id="statModels" class="card-title display-5">0</h2>
                 <p class="card-text">Models Used</p>
-                <p id="statModelsText" class="card-text small text-muted"></p>
+                <p id="statModelsText" class="card-text small text-light"></p>
               </div>
             </div>
           </div>
           <div class="col-md-3">
-            <div class="card text-center bg-dark">
+            <div class="card text-center bg-dark text-white">
               <div class="card-body">
                 <h2 id="statStorage" class="card-title h3">0</h2>
                 <p class="card-text">Storage Used</p>
-                <p id="statStorageText" class="card-text small text-muted"></p>
+                <p id="statStorageText" class="card-text small text-light"></p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- ensure dashboard statistics use a readable text color

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_686a3aefbdd08333bfc5a57ceaa56181