### PR TITLE
Fix theme toggle and filter Raw tag

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
+  <header class="flex items-center justify-between px-4 py-3 shadow-md">
     <h1 class="text-lg font-semibold"><a href="index.html">VisionVault</a></h1>
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -22,7 +22,7 @@
     </nav>
   </header>
   <div class="flex h-[calc(100vh-56px)]">
-    <aside id="sidebar" class="w-64 bg-gray-800 border-r border-gray-700 p-6 overflow-y-auto">
+    <aside id="sidebar" class="w-64 border-r border-gray-700 p-6 overflow-y-auto">
       <h2 class="text-md font-semibold mb-4">Filter</h2>
       <form id="filterForm" class="space-y-4 text-sm">
         <input type="text" id="modelFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Model" />
@@ -38,7 +38,7 @@
       </form>
       <label class="tag-switch mt-3 block text-sm"><input type="checkbox" id="manualTagToggle" class="mr-2" /> Manual tags</label>
     </aside>
-    <main id="gallery" class="flex-1 p-6 overflow-y-auto bg-gray-900">
+    <main id="gallery" class="flex-1 p-6 overflow-y-auto">
       <p class="placeholder text-center text-teal-400">Galerie wird hier erscheinen...</p>
     </main>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
   <link rel="stylesheet" href="style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body class="bg-gray-900 text-white">
-  <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
+<body>
+  <header class="flex items-center justify-between px-4 py-3 shadow-md">
     <h1 class="text-lg font-semibold"><a href="index.html">VisionVault</a></h1>
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -21,7 +21,7 @@
     </nav>
   </header>
   <div class="flex h-[calc(100vh-56px)]">
-    <aside class="w-64 bg-gray-800 border-r border-gray-700 p-6 overflow-y-auto">
+    <aside class="w-64 border-r border-gray-700 p-6 overflow-y-auto">
       <h2 class="text-md font-semibold mb-4">Navigation</h2>
       <nav class="space-y-2 text-sm">
         <a href="index.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -30,7 +30,7 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       </nav>
     </aside>
-    <main class="flex-1 p-6 overflow-y-auto bg-gray-900">
+    <main class="flex-1 p-6 overflow-y-auto">
       <div class="container">
         <h1 class="mb-4">Dashboard</h1>
         <div id="stats" class="row g-4">

--- a/public/style.css
+++ b/public/style.css
@@ -32,6 +32,14 @@ nav.navbar {
   color: var(--accent-violet) !important;
 }
 
+header,
+aside,
+main {
+  background-color: var(--bg-dark);
+  color: var(--text-color);
+  transition: background-color 0.3s, color 0.3s;
+}
+
 /* Eye-catching gradient logo */
 .logo-gradient {
   font-weight: 700;

--- a/public/tags.html
+++ b/public/tags.html
@@ -8,8 +8,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-gray-900 text-white">
-  <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
+<body>
+<header class="flex items-center justify-between px-4 py-3 shadow-md">
     <h1 class="text-lg font-semibold"><a href="index.html">VisionVault</a></h1>
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -20,7 +20,7 @@
     </nav>
   </header>
   <div class="flex h-[calc(100vh-56px)]">
-    <aside class="w-64 bg-gray-800 border-r border-gray-700 p-6 overflow-y-auto">
+  <aside class="w-64 border-r border-gray-700 p-6 overflow-y-auto">
       <h2 class="text-md font-semibold mb-4">Navigation</h2>
       <nav class="space-y-2 text-sm">
         <a href="index.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -29,8 +29,8 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       </nav>
     </aside>
-    <main class="flex-1 p-6 overflow-y-auto bg-gray-900">
-      <div class="bg-gray-800 p-4 rounded shadow">
+    <main class="flex-1 p-6 overflow-y-auto">
+      <div class="p-4 rounded shadow">
         <div id="tagCloud" class="tag-cloud"></div>
       </div>
     </main>

--- a/public/upload.html
+++ b/public/upload.html
@@ -8,8 +8,8 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-gray-900 text-white upload-page">
-  <header class="flex items-center justify-between px-4 py-3 bg-gray-800 shadow-md">
+<body class="upload-page">
+  <header class="flex items-center justify-between px-4 py-3 shadow-md">
     <h1 class="text-lg font-semibold"><a href="index.html">VisionVault</a></h1>
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -20,7 +20,7 @@
     </nav>
   </header>
   <div class="flex h-[calc(100vh-56px)]">
-    <aside class="w-64 bg-gray-800 border-r border-gray-700 p-6 overflow-y-auto">
+    <aside class="w-64 border-r border-gray-700 p-6 overflow-y-auto">
       <h2 class="text-md font-semibold mb-4">Navigation</h2>
       <nav class="space-y-2 text-sm">
         <a href="index.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
@@ -29,7 +29,7 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       </nav>
     </aside>
-    <main class="flex-1 p-6 overflow-y-auto bg-gray-900">
+    <main class="flex-1 p-6 overflow-y-auto">
       <div class="upload-container container text-center">
         <h1 class="my-4">Upload Images</h1>
         <form id="uploadForm">

--- a/src/server.js
+++ b/src/server.js
@@ -117,7 +117,7 @@ function toTags(prompt) {
         .replace(/^"|"$/g, '')
         .toLowerCase()
     )
-    .filter((t) => t);
+    .filter((t) => t && t !== 'raw');
 }
 
 function parseMetadata(meta) {


### PR DESCRIPTION
## Summary
- remove Tailwind background classes from page bodies and containers
- add theme-aware styling for page sections
- ignore "Raw" when extracting tags from prompts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a4020650c8333b93c892136bde86e