### PR TITLE
Add model checkbox filter

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -25,7 +25,6 @@
     <aside id="sidebar" class="w-64 border-r border-gray-700 p-6 overflow-y-auto">
       <h2 class="text-md font-semibold mb-4">Filter</h2>
       <form id="filterForm" class="space-y-4 text-sm">
-        <input type="text" id="modelFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Model" />
         <input type="text" id="keywordFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Keyword" />
         <input type="text" id="resFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Resolution e.g. 512x512" />
         <label class="inline-flex items-center"><input type="checkbox" id="loraFilter" class="mr-2" />LoRA</label>
@@ -36,7 +35,7 @@
         </select>
         <button type="submit" class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded">Apply</button>
       </form>
-      <label class="tag-switch mt-3 block text-sm"><input type="checkbox" id="manualTagToggle" class="mr-2" /> Manual tags</label>
+      <div id="modelList" class="mt-3 space-y-1 text-sm"></div>
     </aside>
     <main id="gallery" class="flex-1 p-6 overflow-y-auto">
       <p class="placeholder text-center text-teal-400">Galerie wird hier erscheinen...</p>

--- a/src/server.js
+++ b/src/server.js
@@ -241,6 +241,17 @@ app.get('/api/tags', (_req, res) => {
   res.json(tags);
 });
 
+// List unique models for filter UI
+app.get('/api/models', (_req, res) => {
+  const rows = db.prepare('SELECT metadata FROM images').all();
+  const models = new Set();
+  rows.forEach((r) => {
+    const meta = parseMetadata(r.metadata || '');
+    if (meta.model) models.add(meta.model);
+  });
+  res.json(Array.from(models).sort());
+});
+
 // Basic statistics for dashboard
 app.get('/api/stats', (_req, res) => {
   const imgCount = db.prepare('SELECT COUNT(*) AS count FROM images').get().count;


### PR DESCRIPTION
## Summary
- remove manual tag toggle and model text input
- add server endpoint to list models
- show checkbox list of models in gallery
- auto-apply filter when selecting a model

## Testing
- `node --check src/server.js`
- `node --check public/main.js`
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686a422e1ecc8333982d2f71ef870b7d