### PR TITLE
Improve dashboard statistics

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -36,6 +36,7 @@
         <button type="submit" class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded">Apply</button>
       </form>
       <div id="modelList" class="mt-3 space-y-1 text-sm"></div>
+      <div id="loraList" class="mt-3 space-y-1 text-sm"></div>
     </aside>
     <main id="gallery" class="flex-1 p-6 overflow-y-auto">
       <p class="placeholder text-center text-teal-400">Galerie wird hier erscheinen...</p>

--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,10 @@
         </div>
         <h2 class="mt-5">Top Tags</h2>
         <ul id="topTags" class="list-inline mt-3"></ul>
+        <h2 class="mt-5">Top Triggers</h2>
+        <ul id="topTriggers" class="list-inline mt-3"></ul>
+        <h2 class="mt-5">Used LoRAs</h2>
+        <ul id="usedLoras" class="list-inline mt-3"></ul>
       </div>
     </main>
   </div>
@@ -148,6 +152,32 @@
         a.href = `gallery.html?tag=${encodeURIComponent(t.tag)}`;
         li.appendChild(a);
         ul.appendChild(li);
+      });
+
+      const trg = document.getElementById('topTriggers');
+      trg.innerHTML = '';
+      data.topTriggers.forEach(t => {
+        const li = document.createElement('li');
+        li.className = 'list-inline-item m-1';
+        const a = document.createElement('a');
+        a.className = 'badge bg-secondary';
+        a.textContent = `${t.tag} (${t.count})`;
+        a.href = `gallery.html?tag=${encodeURIComponent(t.tag)}`;
+        li.appendChild(a);
+        trg.appendChild(li);
+      });
+
+      const ll = document.getElementById('usedLoras');
+      ll.innerHTML = '';
+      data.loras.forEach(l => {
+        const li = document.createElement('li');
+        li.className = 'list-inline-item m-1';
+        const a = document.createElement('a');
+        a.className = 'badge bg-secondary';
+        a.textContent = l;
+        a.href = `gallery.html?loraName=${encodeURIComponent(l)}`;
+        li.appendChild(a);
+        ll.appendChild(li);
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- list LoRAs for filtering and show them on the dashboard
- expose LoRA names and top triggers in API stats
- allow filtering by specific LoRA name
- display LoRA info in metadata drawer
- show top triggers and used LoRAs on dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a49623acc8333b10b69c17067e43f