### PR TITLE
Enable lazy loading for gallery images

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -182,6 +182,8 @@ function createItem(img) {
   });
 
   const el = document.createElement('img');
+  // Use native lazy loading so off-screen images don't load immediately
+  el.loading = 'lazy';
   el.src = img.url;
   el.alt = img.prompt || '';
   el.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- add `loading='lazy'` attribute to gallery images for smarter load behavior

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a7dcb426883339f3835cb6e674ec9