### PR TITLE
Add LoRA Store page

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -17,6 +17,7 @@
       <input type="text" id="search" class="px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Search tags" />
       <button id="deleteSelected" type="button" class="px-3 py-1 bg-red-700 hover:bg-red-600 rounded">Delete</button>
       <a href="tags.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+      <a href="lorastore.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">LoRA Store</a>
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
     </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
       <a href="gallery.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Gallery</a>
       <a href="tags.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+      <a href="lorastore.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">LoRA Store</a>
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
     </nav>
@@ -27,6 +28,7 @@
         <a href="index.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
         <a href="gallery.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Gallery</a>
         <a href="tags.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+        <a href="lorastore.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">LoRA Store</a>
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       </nav>
     </aside>
@@ -58,6 +60,15 @@
                 <h2 id="statModels" class="card-title display-5">0</h2>
                 <p class="card-text">Models Used</p>
                 <p id="statModelsText" class="card-text small text-light"></p>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-3">
+            <div class="card text-center bg-dark text-white">
+              <div class="card-body">
+                <h2 id="statLoraFiles" class="card-title display-5">0</h2>
+                <p class="card-text">LoRA Files</p>
+                <p id="statLoraFilesText" class="card-text small text-light"></p>
               </div>
             </div>
           </div>
@@ -107,11 +118,13 @@
       document.getElementById('statImages').textContent = data.images;
       document.getElementById('statTags').textContent = data.tags;
       document.getElementById('statModels').textContent = data.models;
+      document.getElementById('statLoraFiles').textContent = data.loraFiles;
       const gb = v => (v / (1024 * 1024 * 1024)).toFixed(2);
       document.getElementById('statStorage').textContent = `${gb(data.storage.used)} / ${gb(data.storage.total)} GB`;
       document.getElementById('statImagesText').textContent = `You have ${data.images} images`;
       document.getElementById('statTagsText').textContent = data.topTags.length ? `Top tag: ${data.topTags[0].tag}` : '';
       document.getElementById('statModelsText').textContent = `${data.models} models detected`;
+      document.getElementById('statLoraFilesText').textContent = `${data.loraFiles} stored LoRAs`;
       document.getElementById('statStorageText').textContent = `Using ${gb(data.storage.used)} GB`;
 
       new Chart(document.getElementById('countChart').getContext('2d'), {

--- a/public/lorastore.html
+++ b/public/lorastore.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>VisionVault - Upload</title>
+  <title>VisionVault - LoRA Store</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
@@ -33,17 +33,22 @@
     </aside>
     <main class="flex-1 p-6 overflow-y-auto">
       <div class="upload-container container text-center">
-        <h1 class="my-4">Upload Images</h1>
-        <form id="uploadForm">
-          <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop images here or click</div>
-          <input type="file" id="imageInput" name="images" accept="image/png,image/jpeg" multiple style="display:none" />
+        <h1 class="my-4">LoRA Store</h1>
+        <form id="loraUploadForm" class="mb-4">
+          <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop .safetensors here or click</div>
+          <input type="file" id="loraInput" name="lora" accept=".safetensors" style="display:none" />
         </form>
-        <ul id="uploadQueue" class="list-group mt-3"></ul>
-        <div id="uploadStatus" class="mt-3"></div>
+        <div id="uploadStatus" class="mb-4"></div>
+        <table class="table table-dark table-striped" id="loraTable">
+          <thead>
+            <tr><th>Name</th><th>Uses</th><th>Download</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </div>
     </main>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="upload.js"></script>
+  <script src="lorastore.js"></script>
 </body>
 </html>

--- a/public/lorastore.js
+++ b/public/lorastore.js
@@ -1,0 +1,76 @@
+const dropZone = document.getElementById('dropZone');
+const loraInput = document.getElementById('loraInput');
+const statusEl = document.getElementById('uploadStatus');
+const tableBody = document.querySelector('#loraTable tbody');
+const themeToggle = document.getElementById('themeToggle');
+
+function applyTheme(theme) {
+  if (theme === 'light') {
+    document.body.classList.add('light-theme');
+    themeToggle.textContent = '🌙';
+  } else {
+    document.body.classList.remove('light-theme');
+    themeToggle.textContent = '☀';
+  }
+  localStorage.setItem('vv-theme', theme);
+}
+
+themeToggle.addEventListener('click', () => {
+  const current = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+  const next = current === 'light' ? 'dark' : 'light';
+  applyTheme(next);
+});
+
+applyTheme(localStorage.getItem('vv-theme') || 'dark');
+
+function addFile(file) {
+  const formData = new FormData();
+  formData.append('lora', file);
+  statusEl.textContent = `Uploading ${file.name}...`;
+  fetch('/api/loras/upload', { method: 'POST', body: formData })
+    .then(res => res.json())
+    .then(() => {
+      statusEl.textContent = 'Upload complete';
+      loadTable();
+    })
+    .catch(() => {
+      statusEl.textContent = 'Upload failed';
+    });
+}
+
+dropZone.addEventListener('click', () => loraInput.click());
+dropZone.addEventListener('dragover', (e) => { e.preventDefault(); dropZone.classList.add('dragover'); });
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragover'));
+dropZone.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropZone.classList.remove('dragover');
+  if (e.dataTransfer.files.length) addFile(e.dataTransfer.files[0]);
+});
+loraInput.addEventListener('change', () => { if (loraInput.files[0]) addFile(loraInput.files[0]); });
+
+async function loadTable() {
+  const res = await fetch('/api/lorafiles');
+  const list = await res.json();
+  tableBody.innerHTML = '';
+  list.forEach(item => {
+    const tr = document.createElement('tr');
+    const nameTd = document.createElement('td');
+    const link = document.createElement('a');
+    link.textContent = item.name;
+    link.href = `gallery.html?loraName=${encodeURIComponent(item.name)}`;
+    nameTd.appendChild(link);
+    const usesTd = document.createElement('td');
+    usesTd.textContent = item.uses;
+    const dlTd = document.createElement('td');
+    const dl = document.createElement('a');
+    dl.textContent = 'Download';
+    dl.href = `/loras/${item.id}`;
+    dlTd.appendChild(dl);
+    tr.appendChild(nameTd);
+    tr.appendChild(usesTd);
+    tr.appendChild(dlTd);
+    tableBody.appendChild(tr);
+  });
+}
+
+loadTable();

--- a/public/tags.html
+++ b/public/tags.html
@@ -15,6 +15,7 @@
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
       <a href="gallery.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Gallery</a>
       <a href="tags.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+      <a href="lorastore.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">LoRA Store</a>
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
     </nav>
@@ -26,6 +27,7 @@
         <a href="index.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
         <a href="gallery.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Gallery</a>
         <a href="tags.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
+        <a href="lorastore.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">LoRA Store</a>
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- add LoRA table and endpoints
- support LoRA file upload and download
- list LoRA files with usage counts
- display LoRA stats on dashboard
- add new `lorastore` page and navigation links

## Testing
- `node -c src/server.js`

------
https://chatgpt.com/codex/tasks/task_e_686e0dc6a5548333a0e8e1b382783393