### PR TITLE
Improve gallery filtering

### DIFF
--- a/public/gallery.html
+++ b/public/gallery.html
@@ -26,7 +26,13 @@
       <h2 class="text-md font-semibold mb-4">Filter</h2>
       <form id="filterForm" class="space-y-4 text-sm">
         <input type="text" id="keywordFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Keyword" />
-        <input type="text" id="resFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Resolution e.g. 512x512" />
+        <select id="resFilter" class="w-full px-2 py-1 bg-gray-700 rounded"></select>
+        <div class="flex space-x-2">
+          <select id="yearFilter" class="w-1/2 px-2 py-1 bg-gray-700 rounded"></select>
+          <select id="monthFilter" class="w-1/2 px-2 py-1 bg-gray-700 rounded">
+            <option value="">Month</option>
+          </select>
+        </div>
         <select id="sortSelect" class="w-full px-2 py-1 bg-gray-700 rounded">
           <option value="date_desc">Newest first</option>
           <option value="date_asc">Oldest first</option>
@@ -34,14 +40,14 @@
         </select>
         <button type="submit" class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded">Apply</button>
       </form>
-      <div class="filter-box mt-3">
-        <h3 class="text-sm font-semibold mb-2">Base Models</h3>
-        <div id="modelList" class="space-y-1 text-sm"></div>
-      </div>
-      <div class="filter-box mt-4">
-        <h3 class="text-sm font-semibold mb-2">LoRAs</h3>
-        <div id="loraList" class="space-y-1 text-sm"></div>
-      </div>
+      <details class="filter-box mt-3" open>
+        <summary class="text-sm font-semibold mb-2 cursor-pointer">Base Models</summary>
+        <div id="modelList" class="space-y-1 text-sm mt-2"></div>
+      </details>
+      <details class="filter-box mt-4" open>
+        <summary class="text-sm font-semibold mb-2 cursor-pointer">LoRAs</summary>
+        <div id="loraList" class="space-y-1 text-sm mt-2"></div>
+      </details>
     </aside>
     <main id="gallery" class="flex-1 p-6 overflow-y-auto">
       <p class="placeholder text-center text-teal-400">Galerie wird hier erscheinen...</p>

--- a/public/style.css
+++ b/public/style.css
@@ -138,6 +138,13 @@ img {
   border-radius: 4px;
   background: rgba(0, 0, 0, 0.2);
 }
+.filter-box summary {
+  cursor: pointer;
+  list-style: none;
+}
+.filter-box summary::-webkit-details-marker {
+  display: none;
+}
 
 .light-theme .filter-box {
   background: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
## Summary
- update gallery filter UI to have collapsible sections
- switch resolution filter to dropdown and add year/month controls
- populate resolutions and years from new endpoints
- support resolution and date filtering in backend

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6873a0157a3483338a83f4abdc69c9e0