### PR TITLE
Add password management and session-aware navigation

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -14,6 +14,7 @@
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Home</a>
       <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
     </nav>
   </header>
   <div class="max-w-md mx-auto">
@@ -60,5 +61,6 @@
       refresh();
     });
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/public/auth.js
+++ b/public/auth.js
@@ -1,0 +1,28 @@
+async function updateAuth() {
+  let session = {};
+  try {
+    const res = await fetch('/api/session');
+    session = await res.json();
+  } catch {
+    session = { loggedIn: false };
+  }
+  if (!session.loggedIn || session.role !== 'admin') {
+    document.querySelectorAll('a[href="admin.html"]').forEach(a => a.style.display = 'none');
+  }
+  document.querySelectorAll('a[href="login.html"]').forEach(link => {
+    if (session.loggedIn) {
+      link.textContent = 'Logout';
+      link.href = '#';
+      link.addEventListener('click', async (e) => {
+        e.preventDefault();
+        await fetch('/api/logout', { method: 'POST' });
+        location.href = 'index.html';
+      });
+    }
+  });
+  document.querySelectorAll('.pass-link').forEach(a => {
+    a.style.display = session.loggedIn ? '' : 'none';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', updateAuth);

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -20,6 +20,7 @@
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
       <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
       <button id="nsfwToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle NSFW filter">🔞</button>
     </nav>
@@ -76,6 +77,7 @@
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="auth.js"></script>
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
       <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
       <button id="nsfwToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle NSFW filter">🔞</button>
     </nav>
@@ -33,6 +34,7 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
         <a href="admin.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
         <a href="login.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+        <a href="password.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       </nav>
     </aside>
     <main class="flex-1 p-6 overflow-y-auto">
@@ -198,9 +200,10 @@
         a.textContent = l;
         a.href = `gallery.html?loraName=${encodeURIComponent(l)}`;
         li.appendChild(a);
-        ll.appendChild(li);
+    ll.appendChild(li);
       });
     });
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/public/login.html
+++ b/public/login.html
@@ -14,6 +14,7 @@
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Home</a>
       <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
     </nav>
   </header>
   <div class="max-w-sm mx-auto space-y-6">
@@ -48,5 +49,6 @@
       else alert('Register failed');
     });
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/public/password.html
+++ b/public/password.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>VisionVault - Change Password</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body class="p-6">
+  <header class="mb-4 flex items-center justify-between">
+    <h1 class="logo-gradient"><a href="index.html">VisionVault</a></h1>
+    <nav class="space-x-2 flex items-center">
+      <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Home</a>
+      <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
+      <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
+    </nav>
+  </header>
+  <div class="max-w-sm mx-auto">
+    <form id="changeForm" class="space-y-3">
+      <h2 class="text-lg font-semibold">Change Password</h2>
+      <input id="oldPass" type="password" class="w-full px-2 py-1 rounded bg-gray-700" placeholder="Current Password" required />
+      <input id="newPass" type="password" class="w-full px-2 py-1 rounded bg-gray-700" placeholder="New Password" required />
+      <button class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded" type="submit">Change</button>
+    </form>
+  </div>
+  <script>
+    document.getElementById('changeForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const res = await fetch('/api/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ oldPassword: oldPass.value, newPassword: newPass.value })
+      });
+      if (res.ok) {
+        alert('Password updated');
+        oldPass.value = '';
+        newPass.value = '';
+      } else {
+        alert('Password change failed');
+      }
+    });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/public/tags.html
+++ b/public/tags.html
@@ -18,6 +18,7 @@
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
       <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
       <button id="nsfwToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle NSFW filter">🔞</button>
     </nav>
@@ -32,6 +33,7 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
         <a href="admin.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
         <a href="login.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+        <a href="password.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       </nav>
     </aside>
     <main class="flex-1 p-6 overflow-y-auto">
@@ -41,6 +43,7 @@
     </main>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="auth.js"></script>
   <script src="tags.js"></script>
 </body>
 </html>

--- a/public/upload.html
+++ b/public/upload.html
@@ -18,6 +18,7 @@
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
       <a href="admin.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
       <a href="login.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+      <a href="password.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       <button id="themeToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle theme">☀</button>
       <button id="nsfwToggle" type="button" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded" title="Toggle NSFW filter">🔞</button>
     </nav>
@@ -32,6 +33,7 @@
         <a href="upload.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>
         <a href="admin.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Admin</a>
         <a href="login.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded">Login</a>
+        <a href="password.html" class="block px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded pass-link" style="display:none">Password</a>
       </nav>
     </aside>
     <main class="flex-1 p-6 overflow-y-auto">
@@ -47,6 +49,7 @@
     </main>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="auth.js"></script>
   <script src="upload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add session info endpoint and password change API
- track username in session on login and register
- show admin link only for admins
- turn login links into logout when authenticated
- add password change page and navigation link

## Testing
- `npm install`
- `npm start` *(server starts)*
- `curl -s http://localhost:3000/api/session` *(returns loggedIn false)*

------
https://chatgpt.com/codex/tasks/task_e_68742c0eb0448333952e9fb25d60ffb6