### PR TITLE
Add admin deletion warning and unassign legacy images

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If upgrading from an older version, the database schema is adjusted automaticall
 
 ### User Accounts
 
-The server now includes basic authentication using sessions. An initial `admin` account is created automatically and existing images are assigned to this user. Register new accounts on `login.html` or manage users from `admin.html` (admin only). Regular users can upload and delete only their own images, while guests may browse the gallery.
+The server now includes basic authentication using sessions. An initial `admin` account is created automatically. Images that predate the account system are stored without an owner (displayed as "unknown"). Register new accounts on `login.html` or manage users from `admin.html` (admin only). **Delete the default `admin` user after creating your own admin account.** Regular users can upload and delete only their own images, while guests may browse the gallery.
 
 ### Docker Setup
 

--- a/public/auth.js
+++ b/public/auth.js
@@ -9,6 +9,19 @@ async function updateAuth() {
   if (!session.loggedIn || session.role !== 'admin') {
     document.querySelectorAll('a[href="admin.html"]').forEach(a => a.style.display = 'none');
   }
+  if (session.username === 'admin') {
+    let warn = document.getElementById('adminWarning');
+    if (!warn) {
+      warn = document.createElement('div');
+      warn.id = 'adminWarning';
+      warn.className = 'admin-warning';
+      warn.textContent = "Security notice: delete the default 'admin' account after creating your own.";
+      document.body.prepend(warn);
+    }
+  } else {
+    const warn = document.getElementById('adminWarning');
+    if (warn) warn.remove();
+  }
   document.querySelectorAll('a[href="login.html"]').forEach(link => {
     if (session.loggedIn) {
       link.textContent = 'Logout';

--- a/public/style.css
+++ b/public/style.css
@@ -308,3 +308,12 @@ img {
   height: 220px;
   margin: 0 auto;
 }
+
+.admin-warning {
+  background-color: #dc2626;
+  color: #fff;
+  padding: 0.5rem;
+  text-align: center;
+  margin-bottom: 1rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- update README with security note about the default admin user
- strip default user assignment from server and metadata refresh
- set old images to have no owner when server starts or metadata is refreshed
- show red notification if logged in as the default admin

## Testing
- `npm run refresh-meta`
- `node src/server.js`

------
https://chatgpt.com/codex/tasks/task_e_68742e629e248333bed04b6dba0e0362