### PR TITLE
Add uploader info and admin ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Tag cloud page showing popular keywords
 - NSFW filter toggle driven by the optional `nsfw.txt` blacklist
 - Metadata drawer and fullscreen modal per image
+- Shows uploader name in the metadata drawer
+- Search box filters images by prompt or tags
 - Single or bulk deletion of images
 - User accounts with role-based permissions (admin & user)
+- Admin panel includes a "Take Ownership" action to claim all images
 - Light/dark theme toggle for improved usability
 - Optional `prestart.sh` script to pull updates and reinstall dependencies
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -30,6 +30,7 @@
       </select>
       <button class="w-full px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded" type="submit">Create</button>
     </form>
+    <button id="takeOwnership" class="w-full mt-4 px-4 py-2 bg-indigo-600 hover:bg-indigo-500 rounded">Take Ownership</button>
   </div>
   <script>
     async function refresh() {
@@ -59,6 +60,10 @@
       addName.value = '';
       addPass.value = '';
       refresh();
+    });
+    document.getElementById('takeOwnership').addEventListener('click', async () => {
+      await fetch('/api/admin/take-ownership', { method: 'POST' });
+      alert('All images now belong to you');
     });
   </script>
   <script src="auth.js"></script>

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -14,7 +14,7 @@
     <nav class="space-x-2 flex items-center">
       <a href="index.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Dashboard</a>
       <button id="toggleSidebar" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">☰</button>
-      <input type="text" id="search" class="px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Search tags" />
+      <input type="text" id="search" class="px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Search" />
       <button id="deleteSelected" type="button" class="px-3 py-1 bg-red-700 hover:bg-red-600 rounded">Delete</button>
       <a href="tags.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Tag Cloud</a>
       <a href="upload.html" class="px-3 py-1 bg-gray-700 hover:bg-gray-600 rounded">Upload</a>

--- a/public/main.js
+++ b/public/main.js
@@ -31,6 +31,7 @@ let loading = false;
 let nsfwWords = [];
 let hideNsfw = localStorage.getItem('vv-nsfw') !== 'off';
 let filters = {
+  q: '',
   tag: '',
   model: '',
   loraName: '',
@@ -43,10 +44,14 @@ let filters = {
 
 // Apply tag from query parameter if present
 const urlParams = new URLSearchParams(window.location.search);
+const qParam = urlParams.get('q');
+if (qParam) {
+  filters.q = qParam;
+  if (searchInput) searchInput.value = qParam;
+}
 const tagParam = urlParams.get('tag');
 if (tagParam) {
   filters.tag = tagParam;
-  if (searchInput) searchInput.value = tagParam;
 }
 const sortParam = urlParams.get('sort');
 if (sortParam) {
@@ -74,6 +79,7 @@ if (monthParam) {
 
 function buildQuery() {
   const params = new URLSearchParams();
+  if (filters.q) params.set('q', filters.q);
   if (filters.tag) params.set('tag', filters.tag);
   if (filters.model) params.set('model', filters.model);
   if (filters.loraName) params.set('loraName', filters.loraName);
@@ -382,6 +388,7 @@ function openDrawer(img) {
     <p><strong>Seed:</strong> ${img.seed || ''}</p>
     <p><strong>Size:</strong> ${img.width || '?'}x${img.height || '?'}</p>
     ${img.loras && img.loras.length ? `<p><strong>LoRA:</strong> ${img.loras.join(', ')}</p>` : ''}
+    <p><strong>Uploader:</strong> ${img.uploader || 'unknown'}</p>
   `;
   debug('Opening metadata drawer for image', img.id);
   if (!bsDrawer) bsDrawer = new bootstrap.Offcanvas(drawer);
@@ -425,7 +432,7 @@ if (yearSelect) {
 }
 
 searchInput.addEventListener('input', () => {
-  filters.tag = searchInput.value.trim();
+  filters.q = searchInput.value.trim();
   loadMore(true);
 });
 


### PR DESCRIPTION
## Summary
- display uploader name in image metadata
- support a `q` search filter for prompts or tags
- add admin endpoint & button to take ownership of all images

## Testing
- `npm install`
- `node --check src/server.js`
- `node --check public/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6874342c1abc8333b8016593468782a2