### PR TITLE
Improve admin account creation security

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If upgrading from an older version, the database schema is adjusted automaticall
 
 ### User Accounts
 
-The server now includes basic authentication using sessions. An initial `admin` account is created automatically. Images that predate the account system are stored without an owner (displayed as "unknown"). Register new accounts on `login.html` or manage users from `admin.html` (admin only). **Delete the default `admin` user after creating your own admin account.** Regular users can upload and delete only their own images, while guests may browse the gallery.
+The server now includes basic authentication using sessions. An initial `admin` account is created automatically *only if no other admin users exist*. Images that predate the account system are stored without an owner (displayed as "unknown"). Register new accounts on `login.html` or manage users from `admin.html` (admin only). **Delete the default `admin` user after creating your own admin account.** Regular users can upload and delete only their own images, while guests may browse the gallery.
 
 ### Docker Setup
 

--- a/src/server.js
+++ b/src/server.js
@@ -52,8 +52,11 @@ db.prepare(`CREATE TABLE IF NOT EXISTS users (
   role TEXT DEFAULT 'user'
 )`).run();
 
+const existingAdmin = db
+  .prepare("SELECT id FROM users WHERE role = 'admin' LIMIT 1")
+  .get();
 let admin = db.prepare('SELECT * FROM users WHERE username = ?').get('admin');
-if (!admin) {
+if (!admin && !existingAdmin) {
   const hash = bcrypt.hashSync('admin', 10);
   const info = db
     .prepare('INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)')

--- a/tools/refreshMetadata.js
+++ b/tools/refreshMetadata.js
@@ -24,8 +24,11 @@ db.prepare(`CREATE TABLE IF NOT EXISTS users (
   role TEXT DEFAULT 'user'
 )`).run();
 
+const existingAdmin = db
+  .prepare("SELECT id FROM users WHERE role = 'admin' LIMIT 1")
+  .get();
 let admin = db.prepare('SELECT * FROM users WHERE username = ?').get('admin');
-if (!admin) {
+if (!admin && !existingAdmin) {
   const bcrypt = require('bcrypt');
   const hash = bcrypt.hashSync('admin', 10);
   const info = db


### PR DESCRIPTION
## Summary
- avoid creating default admin if another admin exists
- update README about admin account logic

## Testing
- `npm run refresh-meta`
- `node src/server.js` (started and logged to /tmp/server.log)

------
https://chatgpt.com/codex/tasks/task_e_6874363eb0e08333abe77e8212d661e2