### PR TITLE
Add privacy and user stats features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Filters for tags, model names, LoRA references, resolution, year and month
 - LoRA names detected from prompt references and the `Lora hashes` metadata field
 - Dashboard summarising image counts, unique tags and storage use
+- Dashboard shows top uploaders
 - Tag cloud page showing popular keywords
 - NSFW filter toggle driven by the optional `nsfw.txt` blacklist
 - Metadata drawer and fullscreen modal per image
@@ -18,6 +19,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Search box filters images by prompt or tags
 - Single or bulk deletion of images
 - User accounts with role-based permissions (admin & user)
+- Users can mark uploads as private
 - Admin panel includes a "Take Ownership" action to claim all images
 - Light/dark theme toggle for improved usability
 - Optional `prestart.sh` script to pull updates and reinstall dependencies

--- a/public/auth.js
+++ b/public/auth.js
@@ -36,6 +36,10 @@ async function updateAuth() {
   document.querySelectorAll('.pass-link').forEach(a => {
     a.style.display = session.loggedIn ? '' : 'none';
   });
+  document.querySelectorAll('a[href="upload.html"]').forEach(a => {
+    a.style.display = session.loggedIn ? '' : 'none';
+  });
+  window.currentSession = session;
 }
 
 document.addEventListener('DOMContentLoaded', updateAuth);

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -37,6 +37,7 @@
             <option value="">Month</option>
           </select>
         </div>
+        <select id="userFilter" class="w-full px-2 py-1 bg-gray-700 rounded"></select>
         <select id="sortSelect" class="w-full px-2 py-1 bg-gray-700 rounded">
           <option value="date_desc">Newest first</option>
           <option value="date_asc">Oldest first</option>

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,8 @@
         <ul id="topTriggers" class="list-inline mt-3"></ul>
         <h2 class="mt-5">Used LoRAs</h2>
         <ul id="usedLoras" class="list-inline mt-3"></ul>
+        <h2 class="mt-5">Top Uploaders</h2>
+        <ul id="topUsers" class="list-inline mt-3"></ul>
       </div>
     </main>
   </div>
@@ -202,6 +204,21 @@
         li.appendChild(a);
     ll.appendChild(li);
       });
+
+      const tu = document.getElementById('topUsers');
+      if (tu) {
+        tu.innerHTML = '';
+        data.topUsers.forEach(u => {
+          const li = document.createElement('li');
+          li.className = 'list-inline-item m-1';
+          const a = document.createElement('a');
+          a.className = 'badge bg-secondary';
+          a.textContent = `${u.username} (${u.count})`;
+          a.href = `gallery.html?user=${encodeURIComponent(u.username)}`;
+          li.appendChild(a);
+          tu.appendChild(li);
+        });
+      }
     });
   </script>
   <script src="auth.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -227,6 +227,17 @@ img {
   z-index: 1;
 }
 
+.private-btn {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  cursor: pointer;
+  z-index: 1;
+}
+
 .drop-zone {
   border: 2px dashed var(--accent-teal);
   padding: 0.5rem;

--- a/public/upload.html
+++ b/public/upload.html
@@ -42,6 +42,7 @@
         <form id="uploadForm">
           <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop images here or click</div>
           <input type="file" id="imageInput" name="images" accept="image/png,image/jpeg" multiple style="display:none" />
+          <label class="mt-2 inline-block"><input type="checkbox" id="privateCheckbox" class="mr-1" />Private</label>
         </form>
         <ul id="uploadQueue" class="list-group mt-3"></ul>
         <div id="uploadStatus" class="mt-3"></div>

--- a/public/upload.js
+++ b/public/upload.js
@@ -5,6 +5,7 @@ const statusEl = document.getElementById('uploadStatus');
 const queueEl = document.getElementById('uploadQueue');
 const themeToggle = document.getElementById('themeToggle');
 const nsfwToggle = document.getElementById('nsfwToggle');
+const privateCheckbox = document.getElementById('privateCheckbox');
 
 const queue = [];
 let uploading = false;
@@ -40,6 +41,7 @@ function processQueue() {
   statusEl.textContent = `Uploading ${file.name}...`;
   const formData = new FormData();
   formData.append('images', file);
+  formData.append('private', privateCheckbox && privateCheckbox.checked ? 'true' : 'false');
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/api/upload');
   xhr.upload.onprogress = (e) => {


### PR DESCRIPTION
## Summary
- allow marking uploads as private and add privacy column
- filter gallery by user name
- hide upload/delete features for unauthenticated users
- display top uploaders in dashboard stats
- include private toggle and username filter in UI

## Testing
- `npm install`
- `node src/server.js` *(started then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_687437fd2ee4833398527f22b07b95d6