### PR TITLE
Add caption mode upload/search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - Single or bulk deletion of images
 - User accounts with role-based permissions (admin & user)
 - Users can mark uploads as private
+- Optional Caption Mode stores raw metadata as searchable captions
 - Admin panel includes a "Take Ownership" action to claim all images
 - Light/dark theme toggle for improved usability
 - Optional `prestart.sh` script to pull updates and reinstall dependencies
@@ -46,6 +47,7 @@ Start with an update check using:
 ```
 This script fetches Git updates and installs dependencies if required.
 If upgrading from an older version, the database schema is adjusted automatically.
+The server will also add the new `caption` column and build its search index on startup.
 
 ### User Accounts
 

--- a/public/main.js
+++ b/public/main.js
@@ -445,6 +445,7 @@ function openDrawer(img) {
   drawerContent.innerHTML = `
     <h3>Metadata</h3>
     <p><strong>Prompt:</strong> ${img.prompt || ''}</p>
+    ${img.caption ? `<p><strong>Caption:</strong> ${img.caption}</p>` : ''}
     ${img.negativePrompt ? `<p><strong>Negative:</strong> ${img.negativePrompt}</p>` : ''}
     <p><strong>Model:</strong> ${img.model || ''}</p>
     <p><strong>Seed:</strong> ${img.seed || ''}</p>

--- a/public/upload.html
+++ b/public/upload.html
@@ -43,6 +43,7 @@
           <div id="dropZone" class="drop-zone upload-drop-zone">Drag and drop images here or click</div>
           <input type="file" id="imageInput" name="images" accept="image/png,image/jpeg" multiple style="display:none" />
           <label class="mt-2 inline-block"><input type="checkbox" id="privateCheckbox" class="mr-1" />Private</label>
+          <label class="mt-2 inline-block ms-2"><input type="checkbox" id="captionMode" class="mr-1" />Caption Mode</label>
         </form>
         <ul id="uploadQueue" class="list-group mt-3"></ul>
         <div id="uploadStatus" class="mt-3"></div>

--- a/public/upload.js
+++ b/public/upload.js
@@ -6,6 +6,7 @@ const queueEl = document.getElementById('uploadQueue');
 const themeToggle = document.getElementById('themeToggle');
 const nsfwToggle = document.getElementById('nsfwToggle');
 const privateCheckbox = document.getElementById('privateCheckbox');
+const captionModeCheckbox = document.getElementById('captionMode');
 
 const queue = [];
 let uploading = false;
@@ -42,6 +43,9 @@ function processQueue() {
   const formData = new FormData();
   formData.append('images', file);
   formData.append('private', privateCheckbox && privateCheckbox.checked ? 'true' : 'false');
+  if (captionModeCheckbox) {
+    formData.append('captionMode', captionModeCheckbox.checked ? 'true' : 'false');
+  }
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/api/upload');
   xhr.upload.onprogress = (e) => {


### PR DESCRIPTION
## Summary
- add optional caption column and FTS table on startup
- implement caption-mode uploads
- expose caption text in API and metadata drawer
- support caption search when captionMode query param is set
- provide caption mode option on upload page and JS
- document caption mode and automatic migration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876ab94033c833399aed675e978b57e