### PR TITLE
Add caption search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ VisionVault is a lightweight image board tailored for AI-generated artwork. Uplo
 - User accounts with role-based permissions (admin & user)
 - Users can mark uploads as private
 - Optional Caption Mode stores raw metadata as searchable captions
+- Keyword filter includes an option to run a full-text caption search
 - Admin panel includes a "Take Ownership" action to claim all images
 - Light/dark theme toggle for improved usability
 - Optional `prestart.sh` script to pull updates and reinstall dependencies

--- a/public/gallery.html
+++ b/public/gallery.html
@@ -30,6 +30,7 @@
       <h2 class="text-md font-semibold mb-4">Filter</h2>
       <form id="filterForm" class="space-y-4 text-sm">
         <input type="text" id="keywordFilter" class="w-full px-2 py-1 rounded bg-gray-700 placeholder-gray-400" placeholder="Keyword" />
+        <label class="inline-block"><input type="checkbox" id="captionSearch" class="mr-1" />Caption search</label>
         <select id="resFilter" class="w-full px-2 py-1 bg-gray-700 rounded"></select>
         <div class="flex space-x-2">
           <select id="yearFilter" class="w-1/2 px-2 py-1 bg-gray-700 rounded"></select>

--- a/public/main.js
+++ b/public/main.js
@@ -20,6 +20,7 @@ const loraListEl = document.getElementById('loraList');
 const yearSelect = document.getElementById('yearFilter');
 const monthSelect = document.getElementById('monthFilter');
 const userSelect = document.getElementById('userFilter');
+const captionSearchCb = document.getElementById('captionSearch');
 
 // Simple helper so all debug output is grouped and easy to filter
 function debug(...args) {
@@ -40,7 +41,8 @@ let filters = {
   year: '',
   month: '',
   user: '',
-  sort: 'date_desc'
+  sort: 'date_desc',
+  captionMode: false
 };
 
 let session = {};
@@ -66,6 +68,16 @@ const qParam = urlParams.get('q');
 if (qParam) {
   filters.q = qParam;
   if (searchInput) searchInput.value = qParam;
+}
+const captionParam = urlParams.get('captionMode');
+if (captionParam === 'true') {
+  filters.captionMode = true;
+  if (captionSearchCb) captionSearchCb.checked = true;
+  const kwInput = document.getElementById('keywordFilter');
+  if (kwInput && qParam) {
+    kwInput.value = qParam;
+    if (searchInput) searchInput.value = '';
+  }
 }
 const tagParam = urlParams.get('tag');
 if (tagParam) {
@@ -117,6 +129,7 @@ function buildQuery() {
   if (filters.month) params.set('month', filters.month);
   if (filters.user) params.set('user', filters.user);
   if (filters.sort) params.set('sort', filters.sort);
+  if (filters.captionMode) params.set('captionMode', 'true');
   params.set('offset', offset);
   params.set('limit', limit);
   return params.toString();
@@ -476,7 +489,15 @@ toggleSidebarBtn.addEventListener('click', () => {
 
 filterForm.addEventListener('submit', (e) => {
   e.preventDefault();
-  filters.tag = document.getElementById('keywordFilter').value.trim();
+  const kw = document.getElementById('keywordFilter').value.trim();
+  if (captionSearchCb && captionSearchCb.checked) {
+    filters.q = kw;
+    filters.captionMode = true;
+    filters.tag = '';
+  } else {
+    filters.tag = kw;
+    filters.captionMode = false;
+  }
   filters.resolution = document.getElementById('resFilter').value;
   filters.year = yearSelect ? yearSelect.value : '';
   filters.month = monthSelect ? monthSelect.value : '';


### PR DESCRIPTION
## Summary
- add caption search toggle in gallery filter UI
- support captionMode query param in main.js
- allow caption searches from keyword filter without affecting tag filtering
- document caption search option in README

## Testing
- `npm run refresh-meta --silent`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876aedb9f6c8333ba7a749834a9ba90