### PR TITLE
Add Dockerfile for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+ENV NODE_ENV=production
+ENV DB_PATH=/app/data/visionvault.db
+VOLUME ["/app/public/images", "/app/data"]
+CMD sh -c "ln -sf /app/config/nsfw.txt /app/nsfw.txt && npm start"
+


### PR DESCRIPTION
## Summary
- add `Dockerfile` to allow building a VisionVault image locally

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6876b491c3148333b6594dea7ca4368b